### PR TITLE
Updated ODU2 and EPL Service Examples at MPI1 

### DIFF
--- a/Internet-Drafts/Applicability-Statement/02/mpi1-epl-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-epl-service-config.json
@@ -1,10 +1,10 @@
 {
   "// __TITLE__": "EPL Configuration @ MPI1",
-  "// __LAST_UPDATE__": "May 23, 2018",
+  "// __LAST_UPDATE__": "July 2, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url":
- "http://{{PNC1-ADDR}}/restconf/data/ietf-trans-client-service:etht-svc"
+ "http://{{PNC1}}/restconf/data/ietf-trans-client-service:etht-svc"
   },
   "// __REFERENCE_DRAFTS__": {
     "ietf-te-types@2018-03-05": "draft-ietf-teas-yang-te-14",
@@ -42,9 +42,10 @@
             "access-ltp-id": 1,
             "service-classification-type":
               "ietf-eth-tran-types:port-classification",
-            "// __ DISCUSS __ ingress-egress-bandwidth-profile-name":
+           "// __ DISCUSS __ ingress-egress-bandwidth-profile-name":
               "10G-EPL-BWP",
-            "// vlan-operations": "None: transparent VLAN operations"
+            "// vlan-operations":
+              "None: transparent VLAN operations"
           }
         ],
         "etht-svc-tunnels": [

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
@@ -1,15 +1,15 @@
 {
   "// __TITLE__": "ODU2 Service Configuration @ MPI1",
-  "// __LAST_UPDATE__": "May 23, 2018 (DT Call)",
+  "// __LAST_UPDATE__": "June 28, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-te-types@2018-03-05": "draft-ietf-teas-yang-te-14",
-    "ietf-te@2018-03-03": "draft-ietf-teas-yang-te-14",
-    "ietf-otn-types@2017-10-30": "draft-ietf-ccamp-otn-tunnel-model-01",
-    "ietf-otn-tunnel@2017-10-30": "draft-ietf-ccamp-otn-tunnel-model-01"
+    "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
+    "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -27,34 +27,31 @@
           "// destination": "None: transit tunnel segment",
           "// src-tp-id": "None: transit tunnel segment",
           "// dst-tp-id": "None: transit tunnel segment",
-          "// __ DISCUSS __ ietf-otn-tunnel:payload-treatment": "Do we need this attribute in otn-tunnel?",
+          "// __ ACTION __ ietf-otn-tunnel:payload-treatment": "This attribute should be removed in the next otn-tunnel model update",
           "ietf-otn-tunnel:src-client-signal": "client-signal-ODU2",
-          "// __ DISCUSS __ src-tpn": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tsg": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tributary-slot-count": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tributary-slots": "This information should be provided in the label hop. Should this container to be removed?",
+          "// __ ACTION __ src-tpn": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ src-tsg": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ src-tributary-slot-count": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ src-tributary-slots": "This attribute should be removed in the next otn-tunnel model update",
           "ietf-otn-tunnel:dst-client-signal": "client-signal-ODU2",
-          "// __ DISCUSS __ dst-tpn": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tsg": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tributary-slot-count": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tributary-slots": "This information should be provided in the label hop. Should this container to be removed?",
+          "// __ ACTION __ dst-tpn": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ dst-tsg": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ dst-tributary-slot-count": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ dst-tributary-slots": "This attribute should be removed in the next otn-tunnel model update",
+          "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
           },
           "// __ DEFAULT __ restoration": {
             "// __ DEFAULT __ enable": false
           },
-          "// __ ACTION __ te-topology-identifier": "Need to add the te-topology-identifier information",
-          "// __ ACTION __ te-bandwidth": {
-            "// __ ACTION __ odu-type": "ODU2 (wait for the next OTN Tunnel model update)"
+          "// __ DISCUSS __ te-topology-identifier": "Need to add the te-topology-identifier information.\nWaiting for updates to topology identifiers",
+          "te-bandwidth": {
+            "odu-type": "prot-ODU2"
           },
-          "// __ ACTION __ bidirectional": "Wait for the next TE Tunnel model update to indicate it is a native bidirectional tunnel",
+          "// hierarchical-link": "Not to be specified: transit tunnel segment",
           "p2p-primary-paths": {
-            "name": "mpi1-odu2-service-primary-path",
-            "// __ ACTION __ hierarchical-link": [
-              "Not to be specified: transit tunnel segment",
-              "Wait for the next TE Tunnel model update to move this container under the tunnel"
-            ],
+            "name": "mpi1-odu2-tunnel-primary-path",
             "// __ DISCUSS __ path-scope": "Need to align the model based on the on-going disucssion of the related open issue",
             "path-scope": "path-scope-segment",
             "// te-bandwidth": "None: only the tunnel bandwidth needs to be specified in transport applications",
@@ -64,13 +61,13 @@
                   "// comment": "Tunnel hand-off OTU2 ingress interface (S3-1)",
                   "index": 1,
                   "explicit-route-usage": "route-include-ero",
-                  "unnumbered-hop": {
+                  "num-unnum-hop": {
                     "// node-id": "S3-NODE-ID",
                     "node-id": "10.0.0.3",
                     "// link-tp-id": "S3-1-LTP-ID",
                     "link-tp-id": 1,
                     "hop-type": "STRICT",
-                    "direction": "INCOMING "
+                    "direction": "INCOMING"
                   }
                 },
                 {
@@ -79,34 +76,35 @@
                   "explicit-route-usage": "route-include-ero",
                   "label-hop": {
                     "te-label": {
-                      "// __ DISCUSS __ odu-label": "Need to define the ODU label augmentation",
-                      "// __ DISCUSS __ direction": "Please check proposal below",
+                      "// __ DISCUSS __ odu-label": "How are HO-ODU (ODUk voer OTUk) label represented?",
+                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
                       "direction": "FORWARD "
                     }
                   }
                 },
                 {
                   "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
-                  "index": 3,
+                  "index": 1,
                   "explicit-route-usage": "route-include-ero",
-                  "unnumbered-hop": {
+                  "num-unnum-hop": {
                     "// node-id": "S2-NODE-ID",
                     "node-id": "10.0.0.2",
                     "// link-tp-id": "S2-1-LTP-ID",
                     "link-tp-id": 1,
-                    "// __ DISCUSS __ hop-type": "As discussed in DT call on October 25, 2017",
                     "hop-type": "STRICT",
                     "direction": "OUTGOING"
                   }
                 },
                 {
-                  "// comment": "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
-                  "index": 4,
+                  "// comment": "Tunnel hand-off ODU2 egress label  (ODU2 over OTU4) at S2-1",
+                  "index": 2,
                   "explicit-route-usage": "route-include-ero",
                   "label-hop": {
                     "te-label": {
-                      "// __ DISCUSS __ odu-label": "Need to define the ODU label augmentation",
-                      "// __ DISCUSS __ direction": "Please check proposal below",
+                      "tpn": 1,
+                      "tsg": "tsg-1.25G",
+                      "ts-list": "1-8",
+                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
                       "direction": "FORWARD "
                     }
                   }

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
@@ -1,12 +1,13 @@
 {
   "// __TITLE__": "ODU2 Service Configuration @ MPI1",
-  "// __LAST_UPDATE__": "June 28, 2018",
+  "// __LAST_UPDATE__": "June 29, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
     "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-routing-types@2017-12-04": "rfc8294",
     "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
     "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
@@ -19,25 +20,55 @@
           "name": "mpi1-odu2-service",
           "// identifier": "ODU2-SERVICE-TUNNEL-ID @ MPI1",
           "identifier": 1,
-          "description": "TNBI Example for an ODU2 Service implemented by an ODU2 OTN Tunnel Segment @ MPI1",
+          "description":
+           "ODU2 Service implemented by ODU2 OTN Tunnel Segment @ MPI1",
           "// encoding and switching-type": "ODU",
-          "encoding": "te-types:lsp-encoding-oduk ",
-          "switching-type": "te-types:switching-otn",
+          "encoding": "ietf-te-types:lsp-encoding-oduk ",
+          "switching-type": "ietf-te-types:switching-otn",
           "// source": "None: transit tunnel segment",
           "// destination": "None: transit tunnel segment",
           "// src-tp-id": "None: transit tunnel segment",
           "// dst-tp-id": "None: transit tunnel segment",
-          "// __ ACTION __ ietf-otn-tunnel:payload-treatment": "This attribute should be removed in the next otn-tunnel model update",
-          "ietf-otn-tunnel:src-client-signal": "client-signal-ODU2",
-          "// __ ACTION __ src-tpn": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ src-tsg": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ src-tributary-slot-count": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ src-tributary-slots": "This attribute should be removed in the next otn-tunnel model update",
-          "ietf-otn-tunnel:dst-client-signal": "client-signal-ODU2",
-          "// __ ACTION __ dst-tpn": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ dst-tsg": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ dst-tributary-slot-count": "This attribute should be removed in the next otn-tunnel model update",
-          "// __ ACTION __ dst-tributary-slots": "This attribute should be removed in the next otn-tunnel model update",
+          "// __ ACTION __ ietf-otn-tunnel:payload-treatment": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "ietf-otn-tunnel:src-client-signal":
+           "ietf-otn-types:client-signal-ODU2",
+          "// __ ACTION __ src-tpn": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ src-tsg": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ src-tributary-slot-count": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ src-tributary-slots": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "ietf-otn-tunnel:dst-client-signal":
+           "ietf-otn-types:client-signal-ODU2",
+          "// __ ACTION __ dst-tpn": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ dst-tsg": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ dst-tributary-slot-count": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
+          "// __ ACTION __ dst-tributary-slots": [
+          "This attribute should be removed in the next otn-tunnel",
+           " model update"
+          ],
           "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
@@ -45,72 +76,104 @@
           "// __ DEFAULT __ restoration": {
             "// __ DEFAULT __ enable": false
           },
-          "// __ DISCUSS __ te-topology-identifier": "Need to add the te-topology-identifier information.\nWaiting for updates to topology identifiers",
+          "// __ DISCUSS __ te-topology-identifier": [
+          "Need to add the te-topology-identifier",
+           " information.\nWaiting for updates to topology identifiers"
+          ],
           "te-bandwidth": {
-            "odu-type": "prot-ODU2"
+            "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
           },
-          "// hierarchical-link": "Not to be specified: transit tunnel segment",
+          "// hierarchical-link":
+           "Not to be specified: transit tunnel segment",
           "p2p-primary-paths": {
-            "name": "mpi1-odu2-tunnel-primary-path",
-            "// __ DISCUSS __ path-scope": "Need to align the model based on the on-going disucssion of the related open issue",
-            "path-scope": "path-scope-segment",
-            "// te-bandwidth": "None: only the tunnel bandwidth needs to be specified in transport applications",
-            "explicit-route-objects": {
-              "route-object-include-exclude": [
-                {
-                  "// comment": "Tunnel hand-off OTU2 ingress interface (S3-1)",
-                  "index": 1,
-                  "explicit-route-usage": "route-include-ero",
-                  "num-unnum-hop": {
-                    "// node-id": "S3-NODE-ID",
-                    "node-id": "10.0.0.3",
-                    "// link-tp-id": "S3-1-LTP-ID",
-                    "link-tp-id": 1,
-                    "hop-type": "STRICT",
-                    "direction": "INCOMING"
-                  }
-                },
-                {
-                  "// comment": "Tunnel hand-off ODU2 ingress label (ODU2 over OTU2) at S3-1",
-                  "index": 2,
-                  "explicit-route-usage": "route-include-ero",
-                  "label-hop": {
-                    "te-label": {
-                      "// __ DISCUSS __ odu-label": "How are HO-ODU (ODUk voer OTUk) label represented?",
-                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
-                      "direction": "FORWARD "
+            "p2p-primary-path": [
+              {
+                "name": "mpi1-odu2-tunnel-primary-path",
+                "// __ DISCUSS __ path-scope": [
+                "Need to align the model based on the on-going",
+                 " disucssion of the related open issue"
+                ],
+                "path-scope": "ietf-te-types:path-scope-segment",
+                "// te-bandwidth": [
+                "None: only the tunnel bandwidth needs to be specified",
+                 " in transport applications"
+                ],
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "// comment":
+                       "Tunnel hand-off OTU2 ingress interface (S3-1)",
+                      "index": 1,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "num-unnum-hop": {
+                        "// node-id": "S3-NODE-ID",
+                        "node-id": "10.0.0.3",
+                        "// link-tp-id": "S3-1-LTP-ID",
+                        "link-tp-id": 1,
+                        "hop-type": "STRICT",
+                        "direction": "INCOMING"
+                      }
+                    },
+                    {
+                      "// comment": [
+                      "Tunnel hand-off ODU2 ingress label (ODU2 over",
+                       " OTU2) at S3-1"
+                      ],
+                      "index": 2,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "label-hop": {
+                        "te-label": {
+                          "// __ DISCUSS __ odu-label": [
+                          "How are HO-ODU (ODUk voer OTUk) label",
+                           " represented?"
+                          ],
+                          "// __ ACTION __ direction":
+                           "Check with TE Tunnel authors",
+                          "direction": "FORWARD "
+                        }
+                      }
+                    },
+                    {
+                      "// comment":
+                       "Tunnel hand-off OTU4 egress interface (S2-1)",
+                      "index": 3,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "num-unnum-hop": {
+                        "// node-id": "S2-NODE-ID",
+                        "node-id": "10.0.0.2",
+                        "// link-tp-id": "S2-1-LTP-ID",
+                        "link-tp-id": 1,
+                        "hop-type": "STRICT",
+                        "direction": "OUTGOING"
+                      }
+                    },
+                    {
+                      "// comment": [
+                      "Tunnel hand-off ODU2 egress label (ODU2 over",
+                       " OTU4) at S2-1"
+                      ],
+                      "index": 4,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "label-hop": {
+                        "te-label": {
+                          "ietf-otn-tunnel:tpn": 1,
+                          "ietf-otn-tunnel:tsg":
+                           "ietf-otn-types:tsg-1.25G",
+                          "ietf-otn-tunnel:ts-list": "1-8",
+                          "// __ ACTION __ direction":
+                           "Check with TE Tunnel authors",
+                          "direction": "FORWARD "
+                        }
+                      }
                     }
-                  }
-                },
-                {
-                  "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
-                  "index": 1,
-                  "explicit-route-usage": "route-include-ero",
-                  "num-unnum-hop": {
-                    "// node-id": "S2-NODE-ID",
-                    "node-id": "10.0.0.2",
-                    "// link-tp-id": "S2-1-LTP-ID",
-                    "link-tp-id": 1,
-                    "hop-type": "STRICT",
-                    "direction": "OUTGOING"
-                  }
-                },
-                {
-                  "// comment": "Tunnel hand-off ODU2 egress label  (ODU2 over OTU4) at S2-1",
-                  "index": 2,
-                  "explicit-route-usage": "route-include-ero",
-                  "label-hop": {
-                    "te-label": {
-                      "tpn": 1,
-                      "tsg": "tsg-1.25G",
-                      "ts-list": "1-8",
-                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
-                      "direction": "FORWARD "
-                    }
-                  }
+                  ]
                 }
-              ]
-            }
+              }
+            ]
           }
         }
       ]

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
@@ -1,6 +1,6 @@
 {
   "// __TITLE__": "ODU2 Service Configuration @ MPI1",
-  "// __LAST_UPDATE__": "June 29, 2018",
+  "// __LAST_UPDATE__": "July 2, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
@@ -9,8 +9,10 @@
     "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-routing-types@2017-12-04": "rfc8294",
     "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
-    "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
-    "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
+    "ietf-otn-types@2018-06-07":
+      "draft-ietf-ccamp-otn-tunnel-model-02",
+    "ietf-otn-tunnel@2018-06-07":
+      "draft-ietf-ccamp-otn-tunnel-model-02"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -21,7 +23,7 @@
           "// identifier": "ODU2-SERVICE-TUNNEL-ID @ MPI1",
           "identifier": 1,
           "description":
-           "ODU2 Service implemented by ODU2 OTN Tunnel Segment @ MPI1",
+       "ODU2 Service implemented by ODU2 OTN Tunnel Segment @ MPI1",
           "// encoding and switching-type": "ODU",
           "encoding": "ietf-te-types:lsp-encoding-oduk ",
           "switching-type": "ietf-te-types:switching-otn",
@@ -78,7 +80,7 @@
           },
           "// __ DISCUSS __ te-topology-identifier": [
           "Need to add the te-topology-identifier",
-           " information.\nWaiting for updates to topology identifiers"
+          "information. Waiting for updates to topology identifiers"
           ],
           "te-bandwidth": {
             "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
@@ -95,14 +97,14 @@
                 ],
                 "path-scope": "ietf-te-types:path-scope-segment",
                 "// te-bandwidth": [
-                "None: only the tunnel bandwidth needs to be specified",
+            "None: only the tunnel bandwidth needs to be specified",
                  " in transport applications"
                 ],
                 "explicit-route-objects": {
                   "route-object-include-exclude": [
                     {
                       "// comment":
-                       "Tunnel hand-off OTU2 ingress interface (S3-1)",
+                    "Tunnel hand-off OTU2 ingress interface (S3-1)",
                       "index": 1,
                       "explicit-route-usage":
                        "ietf-te-types:route-include-ero",
@@ -117,7 +119,7 @@
                     },
                     {
                       "// comment": [
-                      "Tunnel hand-off ODU2 ingress label (ODU2 over",
+                    "Tunnel hand-off ODU2 ingress label (ODU2 over",
                        " OTU2) at S3-1"
                       ],
                       "index": 2,
@@ -137,7 +139,7 @@
                     },
                     {
                       "// comment":
-                       "Tunnel hand-off OTU4 egress interface (S2-1)",
+                     "Tunnel hand-off OTU4 egress interface (S2-1)",
                       "index": 3,
                       "explicit-route-usage":
                        "ietf-te-types:route-include-ero",
@@ -152,7 +154,7 @@
                     },
                     {
                       "// comment": [
-                      "Tunnel hand-off ODU2 egress label (ODU2 over",
+                     "Tunnel hand-off ODU2 egress label (ODU2 over",
                        " OTU4) at S2-1"
                       ],
                       "index": 4,

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
@@ -1,12 +1,13 @@
 {
   "// __TITLE__": "ODU2 Tunnel Configuration @ MPI1",
-  "// __LAST_UPDATE__": "June 28, 2018",
+  "// __LAST_UPDATE__": "June 29, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
     "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-routing-types@2017-12-04": "rfc8294",
     "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
     "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
@@ -19,16 +20,19 @@
           "name": "mpi1-odu2-tunnel",
           "// identifier": "ODU2-TUNNEL-ID @ MPI1",
           "identifier": 2,
-          "description": "TNBI Example for an ODU2 Head Tunnel Segment @ MPI1",
+          "description":
+           "TNBI Example for an ODU2 Head Tunnel Segment @ MPI1",
           "// encoding and switching-type": "ODU",
-          "encoding": "te-types:lsp-encoding-oduk ",
-          "switching-type": "te-types:switching-otn",
+          "encoding": "ietf-te-types:lsp-encoding-oduk ",
+          "switching-type": "ietf-te-types:switching-otn",
           "source": "10.0.0.3",
           "// destination": "None: head tunnel segment",
-          "src-tp-id": 1,
+          "src-tp-id": "AAAB",
           "// dst-tp-id": "None: head tunnel segment",
-          "ietf-otn-tunnel:src-client-signal": "client-signal-ODU2",
-          "ietf-otn-tunnel:dst-client-signal": "client-signal-ODU2",
+          "ietf-otn-tunnel:src-client-signal":
+           "ietf-otn-types:client-signal-ODU2",
+          "ietf-otn-tunnel:dst-client-signal":
+           "ietf-otn-types:client-signal-ODU2",
           "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
@@ -36,61 +40,75 @@
           "// __ DEFAULT __ restoration": {
             "// __ DEFAULT __ enable": false
           },
-          "// __ DISCUSS __ te-topology-identifier": "Need to add the te-topology-identifier information.\nWaiting for updates to topology identifiers",
+          "// __ DISCUSS __ te-topology-identifier":
+           "Need to add the te-topology-identifier information",
           "te-bandwidth": {
-            "odu-type": "prot-ODU2"
+            "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
           },
-          "// __ DISCUSS __ hierarchical-link": [
-            "Optional to be specified since the tunnel supports a service and not a link in the client layer"
-          ],
+          "// __ DISCUSS __ hierarchical-link":
+  "Optional: tunnel supports service and not link in the client layer",
           "p2p-primary-paths": {
-            "name": "mpi1-odu2-tunnel-primary-path",
-            "// __ DISCUSS __ path-scope": "Need to align the model based on the on-going disucssion of the related open issue",
-            "path-scope": "path-scope-segment",
-            "// te-bandwidth": "None: only the tunnel bandwidth needs to be specified in transport applications",
-            "explicit-route-objects": {
-              "route-object-include-exclude": [
-                {
-                  "// comment": "Tunnel TTP in node S3",
-                  "index": 1,
-                  "explicit-route-usage": "route-include-ero",
-                  "num-unnum-hop": {
-                    "// node-id": "S3-NODE-ID",
-                    "node-id": "10.0.0.3",
-                    "hop-type": "STRICT",
-                    "// __ ACTION __ direction": "Check with TE Tunnel authors",
-                    "direction": "OUTGOING"
-                  }
-                },
-                {
-                  "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
-                  "index": 1,
-                  "explicit-route-usage": "route-include-ero",
-                  "num-unnum-hop": {
-                    "// node-id": "S2-NODE-ID",
-                    "node-id": "10.0.0.2",
-                    "// link-tp-id": "S2-1-LTP-ID",
-                    "link-tp-id": 1,
-                    "hop-type": "STRICT",
-                    "direction": "OUTGOING"
-                  }
-                },
-                {
-                  "// comment": "Tunnel hand-off ODU2 egress label  (ODU2 over OTU4) at S2-1",
-                  "index": 2,
-                  "explicit-route-usage": "route-include-ero",
-                  "label-hop": {
-                    "te-label": {
-                      "tpn": 2,
-                      "tsg": "tsg-1.25G",
-                      "ts-list": "9-16",
-                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
-                      "direction": "FORWARD "
+            "p2p-primary-path": [
+              {
+                "name": "mpi1-odu2-tunnel-primary-path",
+                "// __ DISCUSS __ path-scope":
+                 "Need to align the model",
+                "path-scope": "ietf-te-types:path-scope-segment",
+                "// te-bandwidth":
+                 "None: only the tunnel bandwidth needed in transport",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "// comment": "Tunnel TTP in node S3",
+                      "index": 1,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "num-unnum-hop": {
+                        "// node-id": "S3-NODE-ID",
+                        "node-id": "10.0.0.3",
+                        "hop-type": "STRICT",
+                        "// __ ACTION __ direction":
+                         "Check with TE Tunnel authors",
+                        "direction": "OUTGOING"
+                      }
+                    },
+                    {
+                      "// comment":
+                       "Tunnel hand-off OTU4 egress interface (S2-1)",
+                      "index": 2,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "num-unnum-hop": {
+                        "// node-id": "S2-NODE-ID",
+                        "node-id": "10.0.0.2",
+                        "// link-tp-id": "S2-1-LTP-ID",
+                        "link-tp-id": 1,
+                        "hop-type": "STRICT",
+                        "direction": "OUTGOING"
+                      }
+                    },
+                    {
+                      "// comment":
+          "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
+                      "index": 3,
+                      "explicit-route-usage":
+                       "ietf-te-types:route-include-ero",
+                      "label-hop": {
+                        "te-label": {
+                          "ietf-otn-tunnel:tpn": 2,
+                          "ietf-otn-tunnel:tsg":
+                           "ietf-otn-types:tsg-1.25G",
+                          "ietf-otn-tunnel:ts-list": "9-16",
+                          "// __ ACTION __ direction":
+                           "Check with TE Tunnel authors",
+                          "direction": "FORWARD "
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
-              ]
-            }
+              }
+            ]
           }
         }
       ]

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
@@ -1,6 +1,6 @@
 {
   "// __TITLE__": "ODU2 Tunnel Configuration @ MPI1",
-  "// __LAST_UPDATE__": "June 29, 2018",
+  "// __LAST_UPDATE__": "July 2, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
@@ -9,8 +9,10 @@
     "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-routing-types@2017-12-04": "rfc8294",
     "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
-    "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
-    "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
+    "ietf-otn-types@2018-06-07":
+      "draft-ietf-ccamp-otn-tunnel-model-02",
+    "ietf-otn-tunnel@2018-06-07":
+      "draft-ietf-ccamp-otn-tunnel-model-02"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -46,7 +48,7 @@
             "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
           },
           "// __ DISCUSS __ hierarchical-link":
-  "Optional: tunnel supports service and not link in the client layer",
+  "Optional: tunnel supports service, not link in the client layer",
           "p2p-primary-paths": {
             "p2p-primary-path": [
               {
@@ -55,7 +57,7 @@
                  "Need to align the model",
                 "path-scope": "ietf-te-types:path-scope-segment",
                 "// te-bandwidth":
-                 "None: only the tunnel bandwidth needed in transport",
+              "None: only the tunnel bandwidth needed in transport",
                 "explicit-route-objects": {
                   "route-object-include-exclude": [
                     {
@@ -74,7 +76,7 @@
                     },
                     {
                       "// comment":
-                       "Tunnel hand-off OTU4 egress interface (S2-1)",
+                     "Tunnel hand-off OTU4 egress interface (S2-1)",
                       "index": 2,
                       "explicit-route-usage":
                        "ietf-te-types:route-include-ero",
@@ -89,7 +91,7 @@
                     },
                     {
                       "// comment":
-          "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
+       "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
                       "index": 3,
                       "explicit-route-usage":
                        "ietf-te-types:route-include-ero",

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
@@ -1,15 +1,15 @@
 {
   "// __TITLE__": "ODU2 Tunnel Configuration @ MPI1",
-  "// __LAST_UPDATE__": "May 23, 2018 (DT call)",
+  "// __LAST_UPDATE__": "June 28, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-te-types@2018-03-05": "draft-ietf-teas-yang-te-14",
-    "ietf-te@2018-03-03": "draft-ietf-teas-yang-te-14",
-    "ietf-otn-types@2017-10-30": "draft-ietf-ccamp-otn-tunnel-model-01",
-    "ietf-otn-tunnel@2017-10-30": "draft-ietf-ccamp-otn-tunnel-model-01"
+    "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
+    "ietf-otn-types@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02",
+    "ietf-otn-tunnel@2018-06-07": "draft-ietf-ccamp-otn-tunnel-model-02"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -23,41 +23,28 @@
           "// encoding and switching-type": "ODU",
           "encoding": "te-types:lsp-encoding-oduk ",
           "switching-type": "te-types:switching-otn",
-          "// __ DISCUSS __source": "S3-NODE-ID. Why ip-address and not te-node-id? ",
           "source": "10.0.0.3",
           "// destination": "None: head tunnel segment",
           "src-tp-id": 1,
           "// dst-tp-id": "None: head tunnel segment",
-          "// __ DISCUSS __ ietf-otn-tunnel:payload-treatment": "Do we need this attribute in otn-tunnel?",
           "ietf-otn-tunnel:src-client-signal": "client-signal-ODU2",
-          "// __ DISCUSS __ src-tpn": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tsg": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tributary-slot-count": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ src-tributary-slots": "This information should be provided in the label hop. Should this container to be removed?",
           "ietf-otn-tunnel:dst-client-signal": "client-signal-ODU2",
-          "// __ DISCUSS __ dst-tpn": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tsg": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tributary-slot-count": "This information should be provided in the label hop. Should this attribute to be removed?",
-          "// __ DISCUSS __ dst-tributary-slots": "This information should be provided in the label hop. Should this container to be removed?",
+          "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
           },
           "// __ DEFAULT __ restoration": {
             "// __ DEFAULT __ enable": false
           },
-          "// __ ACTION __ te-topology-identifier": "Need to add the te-topology-identifier information",
-          "// __ DISCUSS __ te-bandwidth": {
-            "// __ DISCUSS __ odu-type": "ODU2 (wait for the next OTN Tunnel model update)"
+          "// __ DISCUSS __ te-topology-identifier": "Need to add the te-topology-identifier information.\nWaiting for updates to topology identifiers",
+          "te-bandwidth": {
+            "odu-type": "prot-ODU2"
           },
-          "// __ ACTION __ bidirectional": "Wait for the next TE Tunnel model update to indicate it is a native bidirectional tunnel",
+          "// __ DISCUSS __ hierarchical-link": [
+            "Optional to be specified since the tunnel supports a service and not a link in the client layer"
+          ],
           "p2p-primary-paths": {
             "name": "mpi1-odu2-tunnel-primary-path",
-            "// __ DISCUSS __ hierarchical-link": [
-              "Optional to be specified since the tunnel supports a service and not a link in the client layer"
-            ],
-            "// __ ACTION __ hierarchical-link": [
-              "Wait for the next TE Tunnel model update to move this container under the tunnel"
-            ],
             "// __ DISCUSS __ path-scope": "Need to align the model based on the on-going disucssion of the related open issue",
             "path-scope": "path-scope-segment",
             "// te-bandwidth": "None: only the tunnel bandwidth needs to be specified in transport applications",
@@ -67,10 +54,11 @@
                   "// comment": "Tunnel TTP in node S3",
                   "index": 1,
                   "explicit-route-usage": "route-include-ero",
-                  "numbered-hop": {
-                    "// address": "S3-NODE-ID",
-                    "address": "10.0.0.3",
+                  "num-unnum-hop": {
+                    "// node-id": "S3-NODE-ID",
+                    "node-id": "10.0.0.3",
                     "hop-type": "STRICT",
+                    "// __ ACTION __ direction": "Check with TE Tunnel authors",
                     "direction": "OUTGOING"
                   }
                 },
@@ -78,7 +66,7 @@
                   "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
                   "index": 1,
                   "explicit-route-usage": "route-include-ero",
-                  "unnumbered-hop": {
+                  "num-unnum-hop": {
                     "// node-id": "S2-NODE-ID",
                     "node-id": "10.0.0.2",
                     "// link-tp-id": "S2-1-LTP-ID",
@@ -93,8 +81,10 @@
                   "explicit-route-usage": "route-include-ero",
                   "label-hop": {
                     "te-label": {
-                      "// __ DISCUSS __ odu-label": "Need to define the ODU label augmentation",
-                      "// __ DISCUSS __ direction": "Please check proposal below",
+                      "tpn": 2,
+                      "tsg": "tsg-1.25G",
+                      "ts-list": "9-16",
+                      "// __ ACTION __ direction": "Check with TE Tunnel authors",
                       "direction": "FORWARD "
                     }
                   }

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-otn-topology.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-otn-topology.json
@@ -1,19 +1,24 @@
 {
   "// __TITLE__": "ODU Abstract Topology @ MPI1",
-  "// __LAST_UPDATE__": "May 16, 2018",
+  "// __LAST_UPDATE__": "July 2, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "GET",
-    "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-network:networks"
+    "url":
+      "http://{{PNC1-ADDR}}/restconf/data/ietf-network:networks"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-network@2017-12-18": "draft-ietf-i2rs-yang-network-topo-20",
+    "ietf-network@2017-12-18":
+      "draft-ietf-i2rs-yang-network-topo-20",
     "ietf-network-topology@2017-12-18":
       "draft-ietf-i2rs-yang-network-topo-20",
-    "ietf-te-topology@2018-02-21": "draft-ietf-teas-yang-te-topo-15",
+    "ietf-te-topology@2018-02-21":
+      "draft-ietf-teas-yang-te-topo-15",
     "ietf-te-types@2018-02-19": "draft-ietf-teas-yang-te-12",
     "ietf-routing-types@2017-12-04": "rfc8294",
-    "ietf-otn-topology@2017-10-30": "draft-ietf-ccamp-otn-topo-yang-02",
-    "ietf-otn-types@2017-10-30": "draft-ietf-ccamp-otn-tunnel-model-01"
+    "ietf-otn-topology@2017-10-30":
+      "draft-ietf-ccamp-otn-topo-yang-02",
+    "ietf-otn-types@2017-10-30":
+      "draft-ietf-ccamp-otn-tunnel-model-01"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-network:networks": {
@@ -73,16 +78,16 @@
                 "tp-id": "1",
                 "ietf-te-topology:te-tp-id": 1,
                 "ietf-te-topology:te": {
-                  "// __OBSOLETE__ ietf-otn-topology:client-facing": [
+                  "// _OBSOLETE_ ietf-otn-topology:client-facing": [
                     null
                   ],
                   "admin-status": "up",
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU2",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -101,9 +106,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -122,9 +127,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -143,9 +148,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -186,9 +191,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -208,9 +213,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -251,9 +256,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -273,9 +278,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -312,16 +317,16 @@
                 "tp-id": "1",
                 "ietf-te-topology:te-tp-id": 1,
                 "ietf-te-topology:te": {
-                  "// __OBSOLETE__ ietf-otn-topology:client-facing": [
+                  "// _OBSOLETE_ ietf-otn-topology:client-facing": [
                     null
                   ],
                   "admin-status": "up",
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU2",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -341,9 +346,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -363,9 +368,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -406,9 +411,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -428,9 +433,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -450,9 +455,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -489,16 +494,16 @@
                 "tp-id": "1",
                 "ietf-te-topology:te-tp-id": 1,
                 "ietf-te-topology:te": {
-                  "// __OBSOLETE__ ietf-otn-topology:client-facing": [
+                  "// _OBSOLETE_ ietf-otn-topology:client-facing": [
                     null
                   ],
                   "admin-status": "up",
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU2",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -518,9 +523,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -540,9 +545,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -562,9 +567,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -605,9 +610,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -627,9 +632,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -649,9 +654,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -690,14 +695,14 @@
                 "ietf-te-topology:te": {
                   "admin-status": "up",
                   "oper-status": "up",
-                  "// __OBSOLETE__ ietf-otn-topology:client-facing": [
+                  "// _OBSOLETE_ ietf-otn-topology:client-facing": [
                     null
                   ],
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU2",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -715,14 +720,14 @@
                 "ietf-te-topology:te": {
                   "admin-status": "up",
                   "oper-status": "up",
-                  "// __OBSOLETE__ ietf-otn-topology:client-facing": [
+                  "// _OBSOLETE_ ietf-otn-topology:client-facing": [
                     null
                   ],
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU2",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -742,9 +747,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               },
@@ -764,9 +769,9 @@
                   "oper-status": "up",
                   "// ietf-otn-topology:supported-payload-types":
                     "__DISCUSS__",
-                  "// __OBSOLETE__ ietf-otn-topology:protocol-type":
+                  "// _OBSOLETE_ ietf-otn-topology:protocol-type":
                     "ietf-transport-types:prot-OTU4",
-                  "// __OBSOLETE__ ietf-otn-topology:adaptation-type":
+                  "// _OBSOLETE_ ietf-otn-topology:adaptation-type":
                     "ODU"
                 }
               }
@@ -802,9 +807,8 @@
                       {
                         "priority": 0,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for             ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -815,9 +819,8 @@
                       {
                         "priority": 1,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -828,9 +831,8 @@
                       {
                         "priority": 2,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -841,9 +843,8 @@
                       {
                         "priority": 3,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -854,9 +855,8 @@
                       {
                         "priority": 4,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -867,9 +867,8 @@
                       {
                         "priority": 5,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -880,9 +879,8 @@
                       {
                         "priority": 6,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1
@@ -893,9 +891,8 @@
                       {
                         "priority": 7,
                         "te-bandwidth": {
-                          "// __OBSOLETE__ otn": [
-                            "__WARNING__ : pending for               ",
-                            "technology specific bandwidth definition",
+                          "// _OBSOLETE_ otn": [
+  "_WARNING_ : technology specific bandwidth definition",
                             {
                               "rate-type": "ietf-te-types:odu2",
                               "counter": 1


### PR DESCRIPTION
Updated ODU2 and EPL Service Examples at MPI1 based on open issue #31 

- [x] Update the JSON examples for ODU2 service and tunnel with the latest updated versions of the TE and OTN Tunnel models
- [x] Update the JSON example based on the latest TE Tunnel model update to indicate it is a native bidirectional tunnel: pending open issue https://github.com/ietf-mpls-yang/te/issues/25
- [x] Update the Wait for the next TE Tunnel model update to move the hierarchical-link container under the tunnel: pending open issue https://github.com/ietf-mpls-yang/te/issues/30
- [x] @GianmarcoBruno : Validate the update JSON code examples
- [x] @GianmarcoBruno : Create a folded version of the JSON files for inclusion in the Applicability Statement I-D

Postponed to a future update (after IETF102):
- Update the REST operation to avoid replacing the whole te datastore
- Remove for the ietf-otn-tunnel:payload-treatment attribute: pending OTN tunnel model update https://github.com/haomianzheng/IETF-ACTN-YANG-Model/issues/6
- Remove the src-tpn, src-tsg, src-tributary-slot-count, src-tributary-slots, dst-tpn, dst-tsg, dst-tributary-slot-count and dst-tributary-slots attributes/containers: pending OTN tunnel model update https://github.com/haomianzheng/IETF-ACTN-YANG-Model/issues/7
- Check with TE Tunnel model authors how to set the te-label direction

