### PR TITLE
Complete ODU2 and EPL Service Examples at MPI1 (Open Issue #31)

### DIFF
--- a/Internet-Drafts/Applicability-Statement/02/mpi1-epl-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-epl-service-config.json
@@ -1,37 +1,30 @@
 {
   "// __TITLE__": "EPL Configuration @ MPI1",
-  "// __LAST_UPDATE__": "July 2, 2018",
+  "// __LAST_UPDATE__": "July 5, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
-    "url":
- "http://{{PNC1}}/restconf/data/ietf-trans-client-service:etht-svc"
+    "url": "http://{{PNC1}}/restconf/data/ietf-trans-client-service:etht-svc"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-te-types@2018-03-05": "draft-ietf-teas-yang-te-14",
-    "ietf-eth-tran-types@2018-03-01":
-      "draft-zheng-ccamp-otn-client-signal-yang-02",
+    "ietf-te-types@2018-07-01": "draft-ietf-teas-yang-te-16",
+    "ietf-eth-tran-types@2018-07-02.yang": "draft-zheng-ccamp-client-signal-yang-00",
     "ietf-routing-types@2017-12-04": "rfc8294",
-    "ietf-eth-tran-service@2018-03-01":
-      "draft-zheng-ccamp-otn-client-signal-yang-02"
+    "ietf-eth-tran-service@2018-03-01": "draft-zheng-ccamp-client-signal-yang-00"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-eth-tran-service:etht-svc": {
     "etht-svc-instances": [
       {
         "etht-svc-name": "mpi1-epl-service",
-        "etht-svc-descr":
-          "TNBI Example for an EPL over ODU2 Service @ MPI1",
+        "etht-svc-descr": "TNBI Example for an EPL over ODU2 Service @ MPI1",
         "// __ DEFAULT __ etht-svc-type": "p2p-svc",
         "// __ DISCUSS __ te-topology-identifier": [
-         "Would it be possible to use this grouping instead of",
+          "Would it be possible to use this grouping instead of",
           " re-defining the three attributes below?"
         ],
-        "// __ ACTION __ access-provider-id":
-          "Need to add the te-topology-identifier information",
-        "// __ ACTION __ access-client-id":
-          "Need to add the te-topology-identifier information",
-        "// __ ACTION __ topology-id":
-          "Need to add the te-topology-identifier information",
+        "// __ ACTION __ access-provider-id": "Need to add the te-topology-identifier information",
+        "// __ ACTION __ access-client-id": "Need to add the te-topology-identifier information",
+        "// __ ACTION __ topology-id": "Need to add the te-topology-identifier information",
         "etht-svc-access-ports": [
           {
             "// comment": "10GE access interface (S3-1)",
@@ -40,12 +33,9 @@
             "access-node-id": "10.0.0.3",
             "// access-ltp-id": "S3-1-LTP-ID",
             "access-ltp-id": 1,
-            "service-classification-type":
-              "ietf-eth-tran-types:port-classification",
-           "// __ DISCUSS __ ingress-egress-bandwidth-profile-name":
-              "10G-EPL-BWP",
-            "// vlan-operations":
-              "None: transparent VLAN operations"
+            "service-classification-type": "ietf-eth-tran-types:port-classification",
+            "// __ DISCUSS __ ingress-egress-bandwidth-profile-name": "10G-EPL-BWP",
+            "// vlan-operations": "None: transparent VLAN operations"
           }
         ],
         "etht-svc-tunnels": [

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-service-config.json
@@ -1,18 +1,16 @@
 {
   "// __TITLE__": "ODU2 Service Configuration @ MPI1",
-  "// __LAST_UPDATE__": "July 2, 2018",
+  "// __LAST_UPDATE__": "July 5, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-routing-types@2017-12-04": "rfc8294",
-    "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
-    "ietf-otn-types@2018-06-07":
-      "draft-ietf-ccamp-otn-tunnel-model-02",
-    "ietf-otn-tunnel@2018-06-07":
-      "draft-ietf-ccamp-otn-tunnel-model-02"
+    "ietf-te-types@2018-07-01": "draft-ietf-teas-yang-te-16",
+    "ietf-otn-types@2018-06-30.yang": "draft-ietf-ccamp-otn-tunnel-model-03",
+    "ietf-te@2018-07-01": "draft-ietf-teas-yang-te-16",
+    "ietf-otn-tunnel@2018-06-30.yang": "draft-ietf-ccamp-otn-tunnel-model-03"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -22,8 +20,7 @@
           "name": "mpi1-odu2-service",
           "// identifier": "ODU2-SERVICE-TUNNEL-ID @ MPI1",
           "identifier": 1,
-          "description":
-       "ODU2 Service implemented by ODU2 OTN Tunnel Segment @ MPI1",
+          "description": "ODU2 Service implemented by ODU2 OTN Tunnel Segment @ MPI1",
           "// encoding and switching-type": "ODU",
           "encoding": "ietf-te-types:lsp-encoding-oduk ",
           "switching-type": "ietf-te-types:switching-otn",
@@ -31,46 +28,8 @@
           "// destination": "None: transit tunnel segment",
           "// src-tp-id": "None: transit tunnel segment",
           "// dst-tp-id": "None: transit tunnel segment",
-          "// __ ACTION __ ietf-otn-tunnel:payload-treatment": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "ietf-otn-tunnel:src-client-signal":
-           "ietf-otn-types:client-signal-ODU2",
-          "// __ ACTION __ src-tpn": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ src-tsg": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ src-tributary-slot-count": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ src-tributary-slots": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "ietf-otn-tunnel:dst-client-signal":
-           "ietf-otn-types:client-signal-ODU2",
-          "// __ ACTION __ dst-tpn": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ dst-tsg": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ dst-tributary-slot-count": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
-          "// __ ACTION __ dst-tributary-slots": [
-          "This attribute should be removed in the next otn-tunnel",
-           " model update"
-          ],
+          "ietf-otn-tunnel:src-client-signal": "ietf-otn-types:client-signal-ODU2",
+          "ietf-otn-tunnel:dst-client-signal": "ietf-otn-types:client-signal-ODU2",
           "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
@@ -79,35 +38,32 @@
             "// __ DEFAULT __ enable": false
           },
           "// __ DISCUSS __ te-topology-identifier": [
-          "Need to add the te-topology-identifier",
-          "information. Waiting for updates to topology identifiers"
+            "Need to add the te-topology-identifier",
+            "information. Waiting for updates to topology identifiers"
           ],
           "te-bandwidth": {
             "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
           },
-          "// hierarchical-link":
-           "Not to be specified: transit tunnel segment",
+          "// hierarchical-link": "None: transit tunnel segment",
           "p2p-primary-paths": {
             "p2p-primary-path": [
               {
-                "name": "mpi1-odu2-tunnel-primary-path",
+                "name": "mpi1-odu2-service-primary-path",
                 "// __ DISCUSS __ path-scope": [
-                "Need to align the model based on the on-going",
-                 " disucssion of the related open issue"
+                  "Need to align the model based on the on-going",
+                  " disucssion of the related open issue"
                 ],
                 "path-scope": "ietf-te-types:path-scope-segment",
                 "// te-bandwidth": [
-            "None: only the tunnel bandwidth needs to be specified",
-                 " in transport applications"
+                  "None: only the tunnel bandwidth needs to be specified",
+                  " in transport applications"
                 ],
                 "explicit-route-objects": {
                   "route-object-include-exclude": [
                     {
-                      "// comment":
-                    "Tunnel hand-off OTU2 ingress interface (S3-1)",
+                      "// comment": "Tunnel hand-off OTU2 ingress interface (S3-1)",
                       "index": 1,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "num-unnum-hop": {
                         "// node-id": "S3-NODE-ID",
                         "node-id": "10.0.0.3",
@@ -119,30 +75,26 @@
                     },
                     {
                       "// comment": [
-                    "Tunnel hand-off ODU2 ingress label (ODU2 over",
-                       " OTU2) at S3-1"
+                        "Tunnel hand-off ODU2 ingress label (ODU2 over",
+                        " OTU2) at S3-1"
                       ],
                       "index": 2,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "label-hop": {
                         "te-label": {
                           "// __ DISCUSS __ odu-label": [
-                          "How are HO-ODU (ODUk voer OTUk) label",
-                           " represented?"
+                            "How are HO-ODU (ODUk voer OTUk) label",
+                            " represented?"
                           ],
-                          "// __ ACTION __ direction":
-                           "Check with TE Tunnel authors",
+                          "// __ ACTION __ direction": "Check with TE Tunnel authors",
                           "direction": "FORWARD "
                         }
                       }
                     },
                     {
-                      "// comment":
-                     "Tunnel hand-off OTU4 egress interface (S2-1)",
+                      "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
                       "index": 3,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "num-unnum-hop": {
                         "// node-id": "S2-NODE-ID",
                         "node-id": "10.0.0.2",
@@ -154,20 +106,17 @@
                     },
                     {
                       "// comment": [
-                     "Tunnel hand-off ODU2 egress label (ODU2 over",
-                       " OTU4) at S2-1"
+                        "Tunnel hand-off ODU2 egress label (ODU2 over",
+                        " OTU4) at S2-1"
                       ],
                       "index": 4,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "label-hop": {
                         "te-label": {
                           "ietf-otn-tunnel:tpn": 1,
-                          "ietf-otn-tunnel:tsg":
-                           "ietf-otn-types:tsg-1.25G",
+                          "ietf-otn-tunnel:tsg": "ietf-otn-types:tsg-1.25G",
                           "ietf-otn-tunnel:ts-list": "1-8",
-                          "// __ ACTION __ direction":
-                           "Check with TE Tunnel authors",
+                          "// __ ACTION __ direction": "Check with TE Tunnel authors",
                           "direction": "FORWARD "
                         }
                       }

--- a/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
+++ b/Internet-Drafts/Applicability-Statement/02/mpi1-odu2-tunnel-config.json
@@ -1,18 +1,16 @@
 {
   "// __TITLE__": "ODU2 Tunnel Configuration @ MPI1",
-  "// __LAST_UPDATE__": "July 2, 2018",
+  "// __LAST_UPDATE__": "July 5, 2018",
   "// __RESTCONF_OPERATION__": {
     "operation": "PUT",
     "url": "http://{{PNC1-ADDR}}/restconf/data/ietf-te:te"
   },
   "// __REFERENCE_DRAFTS__": {
-    "ietf-te-types@2018-06-12": "draft-ietf-teas-yang-te-15",
     "ietf-routing-types@2017-12-04": "rfc8294",
-    "ietf-te@2018-06-12": "draft-ietf-teas-yang-te-15",
-    "ietf-otn-types@2018-06-07":
-      "draft-ietf-ccamp-otn-tunnel-model-02",
-    "ietf-otn-tunnel@2018-06-07":
-      "draft-ietf-ccamp-otn-tunnel-model-02"
+    "ietf-te-types@2018-07-01": "draft-ietf-teas-yang-te-16",
+    "ietf-otn-types@2018-06-30.yang": "draft-ietf-ccamp-otn-tunnel-model-03",
+    "ietf-te@2018-07-01": "draft-ietf-teas-yang-te-16",
+    "ietf-otn-tunnel@2018-06-30.yang": "draft-ietf-ccamp-otn-tunnel-model-03"
   },
   "// __MISSING_ATTRIBUTES__": true,
   "ietf-te:te": {
@@ -22,19 +20,17 @@
           "name": "mpi1-odu2-tunnel",
           "// identifier": "ODU2-TUNNEL-ID @ MPI1",
           "identifier": 2,
-          "description":
-           "TNBI Example for an ODU2 Head Tunnel Segment @ MPI1",
+          "description": "TNBI Example for an ODU2 Head Tunnel Segment @ MPI1",
           "// encoding and switching-type": "ODU",
           "encoding": "ietf-te-types:lsp-encoding-oduk ",
           "switching-type": "ietf-te-types:switching-otn",
           "source": "10.0.0.3",
           "// destination": "None: head tunnel segment",
+          "//__DISCUSS__ src-tp-id": "Why the value 1 was not ok during validation?",
           "src-tp-id": "AAAB",
           "// dst-tp-id": "None: head tunnel segment",
-          "ietf-otn-tunnel:src-client-signal":
-           "ietf-otn-types:client-signal-ODU2",
-          "ietf-otn-tunnel:dst-client-signal":
-           "ietf-otn-types:client-signal-ODU2",
+          "ietf-otn-tunnel:src-client-signal": "ietf-otn-types:client-signal-ODU2",
+          "ietf-otn-tunnel:dst-client-signal": "ietf-otn-types:client-signal-ODU2",
           "bidirectional": true,
           "// __ DEFAULT __ protection": {
             "// __ DEFAULT __ enable": false
@@ -42,44 +38,36 @@
           "// __ DEFAULT __ restoration": {
             "// __ DEFAULT __ enable": false
           },
-          "// __ DISCUSS __ te-topology-identifier":
-           "Need to add the te-topology-identifier information",
+          "// __ DISCUSS __ te-topology-identifier": "Need to add the te-topology-identifier information",
           "te-bandwidth": {
             "ietf-otn-tunnel:odu-type": "ietf-otn-types:prot-ODU2"
           },
-          "// __ DISCUSS __ hierarchical-link":
-  "Optional: tunnel supports service, not link in the client layer",
+          "// __ DISCUSS __ hierarchical-link": "Optional: tunnel supports service, not link in the client layer",
           "p2p-primary-paths": {
             "p2p-primary-path": [
               {
                 "name": "mpi1-odu2-tunnel-primary-path",
-                "// __ DISCUSS __ path-scope":
-                 "Need to align the model",
+                "// __ DISCUSS __ path-scope": "Need to align the model",
                 "path-scope": "ietf-te-types:path-scope-segment",
-                "// te-bandwidth":
-              "None: only the tunnel bandwidth needed in transport",
+                "// te-bandwidth": "None: only the tunnel bandwidth needed in transport",
                 "explicit-route-objects": {
                   "route-object-include-exclude": [
                     {
                       "// comment": "Tunnel TTP in node S3",
                       "index": 1,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "num-unnum-hop": {
                         "// node-id": "S3-NODE-ID",
                         "node-id": "10.0.0.3",
                         "hop-type": "STRICT",
-                        "// __ ACTION __ direction":
-                         "Check with TE Tunnel authors",
+                        "// __ ACTION __ direction": "Check with TE Tunnel authors",
                         "direction": "OUTGOING"
                       }
                     },
                     {
-                      "// comment":
-                     "Tunnel hand-off OTU4 egress interface (S2-1)",
+                      "// comment": "Tunnel hand-off OTU4 egress interface (S2-1)",
                       "index": 2,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "num-unnum-hop": {
                         "// node-id": "S2-NODE-ID",
                         "node-id": "10.0.0.2",
@@ -90,19 +78,15 @@
                       }
                     },
                     {
-                      "// comment":
-       "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
+                      "// comment": "Tunnel hand-off ODU2 egress label (ODU2 over OTU4) at S2-1",
                       "index": 3,
-                      "explicit-route-usage":
-                       "ietf-te-types:route-include-ero",
+                      "explicit-route-usage": "ietf-te-types:route-include-ero",
                       "label-hop": {
                         "te-label": {
                           "ietf-otn-tunnel:tpn": 2,
-                          "ietf-otn-tunnel:tsg":
-                           "ietf-otn-types:tsg-1.25G",
+                          "ietf-otn-tunnel:tsg": "ietf-otn-types:tsg-1.25G",
                           "ietf-otn-tunnel:ts-list": "9-16",
-                          "// __ ACTION __ direction":
-                           "Check with TE Tunnel authors",
+                          "// __ ACTION __ direction": "Check with TE Tunnel authors",
                           "direction": "FORWARD "
                         }
                       }


### PR DESCRIPTION
Complete ODU2 and EPL Service Examples at MPI1 to complete the pending action points identified in open issue #31 

- [ ] Align the code with the latest versions of the TE Topology and Tunnel models
  - draft-ietf-teas-yang-te-16
  - draft-ietf-ccamp-otn-tunnel-model-03
  - draft-zheng-ccamp-client-signal-yang-00
- [ ] Update the REST operation to avoid replacing the whole te datastore
- [ ] Remove for the ietf-otn-tunnel:payload-treatment attribute: pending OTN tunnel model update haomianzheng/IETF-ACTN-YANG-Model#6
- [ ] Remove the src-tpn, src-tsg, src-tributary-slot-count, src-tributary-slots, dst-tpn, dst-tsg, dst-tributary-slot-count and dst-tributary-slots attributes/containers: pending OTN tunnel model update haomianzheng/IETF-ACTN-YANG-Model#7
- [ ] Check with TE Tunnel model authors how to set the te-label direction
- [ ] Add the te-topology-identifier information: pending pull request #10
- [ ] Check with TE Tunnel model authors why the source and destination attributes are defined as ip-address and not as te-node-id: see ietf-mpls-yang/te#35

